### PR TITLE
ENG-1338: Add explicit IV to better support specific java8 versions

### DIFF
--- a/src/test/java/com/agiletec/aps/AllTests.java
+++ b/src/test/java/com/agiletec/aps/AllTests.java
@@ -77,6 +77,7 @@ import org.entando.entando.aps.system.services.entity.AbstractEntityTypeServiceT
 import org.entando.entando.aps.system.services.guifragment.GuiFragmentManagerIntegrationTest;
 import org.entando.entando.aps.system.services.i18n.TestApiI18nLabelInterface;
 import org.entando.entando.aps.system.services.oauth2.*;
+import org.entando.entando.aps.system.services.page.PageTokenManagerTest;
 import org.entando.entando.aps.system.services.storage.LocalStorageManagerIntegrationTest;
 import org.entando.entando.aps.system.services.storage.StorageManagerUtilTest;
 import org.entando.entando.aps.system.services.userprofile.UserProfileManagerAspectTest;
@@ -101,6 +102,8 @@ public class AllTests {
     public static Test suite() {
         TestSuite suite = new TestSuite("Test for APS");
 
+        //
+        suite.addTest(new JUnit4TestAdapter(PageTokenManagerTest.class));
         //
         suite.addTestSuite(EntLoggingTest.class);
         //

--- a/src/test/java/org/entando/entando/aps/system/services/page/PageTokenManagerTest.java
+++ b/src/test/java/org/entando/entando/aps/system/services/page/PageTokenManagerTest.java
@@ -1,0 +1,33 @@
+package org.entando.entando.aps.system.services.page;
+
+import com.agiletec.aps.system.services.baseconfig.ConfigInterface;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PageTokenManagerTest {
+
+    public static final String TEST_PAGE_CODE = "test_page";
+
+    @Mock
+    ConfigInterface mockedConfigManager;
+
+    @Test
+    public void testTokenEncryptDecrypt() throws Exception {
+        PageTokenManager pageTokenManager = new PageTokenManager();
+        Mockito.doReturn("ZDQdIPZ0XOc8izJJCiIv").when(mockedConfigManager).getParam("page_preview_hash");
+        pageTokenManager.setConfigManager(mockedConfigManager);
+        pageTokenManager.init();
+        String token = pageTokenManager.encrypt(TEST_PAGE_CODE);
+        Assert.assertNotNull(token);
+        String code = pageTokenManager.decrypt(token);
+        Assert.assertNotNull(code);
+        Assert.assertEquals(TEST_PAGE_CODE, code);
+    }
+}


### PR DESCRIPTION
specific=old but not too old

From now on the minimal java version will be 1.8.0_265