### PR TITLE
ENG-2405 and ENG-2450 Allowing LocalDateTime object as filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-core-parent</artifactId>
-        <version>6.3.13</version>
+        <version>6.3.14</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-engine</artifactId>

--- a/src/main/java/com/agiletec/aps/system/common/AbstractSearcherDAO.java
+++ b/src/main/java/com/agiletec/aps/system/common/AbstractSearcherDAO.java
@@ -19,6 +19,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -215,6 +216,8 @@ public abstract class AbstractSearcherDAO extends AbstractDAO {
             stat.setBigDecimal(index, (BigDecimal) object);
         } else if (object instanceof Boolean) {
             stat.setString(index, ((Boolean) object).toString());
+        } else if (object instanceof LocalDateTime) {
+            stat.setObject(index, Timestamp.valueOf((LocalDateTime)object));
         } else {
             stat.setObject(index, object);
         }

--- a/src/test/java/org/entando/entando/web/analysis/AnalysisControllerTest.java
+++ b/src/test/java/org/entando/entando/web/analysis/AnalysisControllerTest.java
@@ -127,7 +127,7 @@ class AnalysisControllerTest extends AbstractControllerTest {
 
         result.andExpect(status().isOk());
         result.andDo(MockMvcResultHandlers.print());
-        result.andExpect(content().contentType("application/json;charset=UTF-8"));
+        result.andExpect(content().contentType("application/json"));
         checkByComponentType(result, "widgets");
         checkByComponentType(result, "fragments");
         checkByComponentType(result, "pages");


### PR DESCRIPTION
The change made on AnalysisControllerTest.java is because MediaType.APPLICATION_JSON_UTF8 is now deprecated since: "major browsers like Chrome now comply with the specification and interpret correctly UTF-8 special characters without requiring a charset=UTF-8 parameter."
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/MediaType.html#APPLICATION_JSON_UTF8