### PR TITLE
ENG-2332: Fix issue of applying filter when sorting

### DIFF
--- a/src/main/java/com/agiletec/aps/system/common/AbstractSearcherDAO.java
+++ b/src/main/java/com/agiletec/aps/system/common/AbstractSearcherDAO.java
@@ -293,6 +293,9 @@ public abstract class AbstractSearcherDAO extends AbstractDAO {
     }
 
     protected boolean addFilters(FieldSearchFilter filter, StringBuffer query, boolean hasAppendWhereClause) {
+        if (filter.isSortOnly()) {
+            return hasAppendWhereClause;
+        }
         hasAppendWhereClause = this.verifyWhereClauseAppend(query, hasAppendWhereClause);
         String tableFieldName = this.getTableFieldName(filter.getKey());
         if (filter.getAllowedValues() != null && filter.getAllowedValues().size() > 0) {

--- a/src/main/java/com/agiletec/aps/system/common/FieldSearchFilter.java
+++ b/src/main/java/com/agiletec/aps/system/common/FieldSearchFilter.java
@@ -50,6 +50,7 @@ public class FieldSearchFilter<T> implements Serializable {
     private LikeOptionType likeOptionType;
     private boolean nullOption;
     private boolean notOption;
+    private boolean sortOnly;
 
     private List<T> allowedValues;
 
@@ -289,7 +290,15 @@ public class FieldSearchFilter<T> implements Serializable {
         }
         this.notOption = notOption;
     }
-    
+
+    public boolean isSortOnly() {
+        return sortOnly;
+    }
+
+    public void setSortOnly(boolean sortOnly) {
+        this.sortOnly = sortOnly;
+    }
+
     public List<T> getAllowedValues() {
         return allowedValues;
     }

--- a/src/main/java/org/entando/entando/web/common/model/RestListRequest.java
+++ b/src/main/java/org/entando/entando/web/common/model/RestListRequest.java
@@ -173,6 +173,7 @@ public class RestListRequest {
     private FieldSearchFilter buildSortFilter() {
         if (StringUtils.isNotBlank(this.escapeSql(this.getSort()))) {
             FieldSearchFilter sort = new FieldSearchFilter(this.getSort());
+            sort.setSortOnly(true);
             if (StringUtils.isNotBlank(this.getDirection())) {
                 if (!this.getDirection().equalsIgnoreCase(FieldSearchFilter.ASC_ORDER) && !this.getDirection().equalsIgnoreCase(FieldSearchFilter.DESC_ORDER)) {
                     this.setDirection(DIRECTION_VALUE_DEFAULT);

--- a/src/test/java/org/entando/entando/web/pagemodel/PageModelControllerIntegrationTest.java
+++ b/src/test/java/org/entando/entando/web/pagemodel/PageModelControllerIntegrationTest.java
@@ -679,6 +679,15 @@ class PageModelControllerIntegrationTest extends AbstractControllerIntegrationTe
 
     }
 
+    @Test
+    void shouldSortWithoutApplyingFilterToTheSortingAttribute() throws Exception {
+        ResultActions result = mockMvc.perform(
+                get("/pageModels?sort=pluginCode")
+                        .header("Authorization", "Bearer " + accessToken));
+        result.andExpect(status().isOk());
+        result.andExpect(jsonPath("$.metaData.totalItems", is(3)));
+    }
+
     private String getJsonRequest(String filename) throws Exception {
         InputStream isJsonPostValid = this.getClass().getResourceAsStream(filename);
         String result = FileTextReader.getText(isJsonPostValid);


### PR DESCRIPTION
When calling an endpoint with sorting (`?sort=<attributeName>`), filter is being applyied if the endpoint implementation uses `AbstractSearcherDAO` to perform the search.
The resulting query will have `<attributeName> is not null` filter, which is not correct, since only sorting was applied to that attribuete. This will cause the error described in ENG-2332.