### PR TITLE
ENG-3213 Avoided NPE in PageConfigurationValidator and added tests

### DIFF
--- a/src/main/java/org/entando/entando/web/page/validator/PageConfigurationValidator.java
+++ b/src/main/java/org/entando/entando/web/page/validator/PageConfigurationValidator.java
@@ -13,7 +13,7 @@
  */
 package org.entando.entando.web.page.validator;
 
-import org.entando.entando.aps.system.services.jsonpatch.validator.JsonPatchValidator;
+import java.util.Map;
 import org.entando.entando.aps.system.services.widgettype.WidgetType;
 import org.entando.entando.aps.system.services.widgettype.WidgetTypeManager;
 import org.entando.entando.web.common.validator.AbstractPaginationValidator;
@@ -21,16 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
-import java.util.Map;
-
-
 @Component
 public class PageConfigurationValidator extends AbstractPaginationValidator {
 
     private static final String ERRCODE_OPERATION_WIDEGT_CONF_NOT_OVERRIDABLE = "10";
-
-    @Autowired
-    private JsonPatchValidator jsonPatchValidator;
 
     @Autowired
     private WidgetTypeManager widgetTypeManager;
@@ -38,7 +32,7 @@ public class PageConfigurationValidator extends AbstractPaginationValidator {
     public void validateWidgetConfigOverridable(String widgetCode, Map<String, Object> widgetConfig, Errors errors) {
 
         final WidgetType type = widgetTypeManager.getWidgetType(widgetCode);
-        if (null != widgetConfig && !widgetConfig.isEmpty() && type.isReadonlyPageWidgetConfig()) {
+        if (null != widgetConfig && !widgetConfig.isEmpty() && type != null && type.isReadonlyPageWidgetConfig()) {
             errors.rejectValue("code", ERRCODE_OPERATION_WIDEGT_CONF_NOT_OVERRIDABLE,
                     new String[]{widgetCode}, "page.widgetconfig.notoverridable");
         }

--- a/src/test/java/org/entando/entando/web/page/validator/PageConfigurationValidatorTest.java
+++ b/src/test/java/org/entando/entando/web/page/validator/PageConfigurationValidatorTest.java
@@ -1,0 +1,70 @@
+package org.entando.entando.web.page.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.util.Maps;
+import org.entando.entando.aps.system.services.widgettype.WidgetType;
+import org.entando.entando.aps.system.services.widgettype.WidgetTypeManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.Errors;
+
+@ExtendWith(MockitoExtension.class)
+class PageConfigurationValidatorTest {
+
+    private static final String WIDGET_CODE = "navigation_menu";
+    private static final Map<String, Object> WIDGET_CONFIG = Maps.newHashMap("config_key", "config_value");
+
+    @Mock
+    private Errors errors;
+
+    @Mock
+    private WidgetType widgetType;
+
+    @Mock
+    private WidgetTypeManager widgetTypeManager;
+
+    @InjectMocks
+    private PageConfigurationValidator validator;
+
+    @Test
+    void testValidateWidgetConfigOverridableNullConfig() {
+        Mockito.when(widgetTypeManager.getWidgetType(WIDGET_CODE)).thenReturn(widgetType);
+        validator.validateWidgetConfigOverridable(WIDGET_CODE, null, errors);
+        Mockito.verifyNoInteractions(errors);
+    }
+
+    @Test
+    void testValidateWidgetConfigOverridableTypeNotFound() {
+        validator.validateWidgetConfigOverridable(WIDGET_CODE, null, errors);
+        Mockito.verifyNoInteractions(errors);
+    }
+
+    @Test
+    void testValidateWidgetConfigOverridableTypeNotReadOnly() {
+        Mockito.when(widgetTypeManager.getWidgetType(WIDGET_CODE)).thenReturn(widgetType);
+        validator.validateWidgetConfigOverridable(WIDGET_CODE, WIDGET_CONFIG, errors);
+        Mockito.verifyNoInteractions(errors);
+    }
+
+    @Test
+    void testValidateWidgetConfigOverridableEmptyConfig() {
+        Mockito.when(widgetTypeManager.getWidgetType(WIDGET_CODE)).thenReturn(widgetType);
+        validator.validateWidgetConfigOverridable(WIDGET_CODE, new HashMap<>(), errors);
+        Mockito.verifyNoInteractions(errors);
+    }
+
+    @Test
+    void testValidateWidgetConfigOverridableTypeReadOnly() {
+        Mockito.when(widgetType.isReadonlyPageWidgetConfig()).thenReturn(true);
+        Mockito.when(widgetTypeManager.getWidgetType(WIDGET_CODE)).thenReturn(widgetType);
+        validator.validateWidgetConfigOverridable(WIDGET_CODE, WIDGET_CONFIG, errors);
+        Mockito.verify(errors).rejectValue(ArgumentMatchers.eq("code"),
+                ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
Just avoided the `NullPointerException`. If an invalid widget is used by the front-end, the proper `ResourceNotFoundException` will be thrown by `PageService`.