### PR TITLE
ENG-3498: Make sure the page position is matching the index

### DIFF
--- a/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
+++ b/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
@@ -225,27 +225,7 @@ public class PageService implements IComponentExistsService, IPageService,
                         res.add(dtoBuilder.convert(childD));
                     }
                 })));
-        // make sure the position is matching the index
-        for (int i = 0; i < res.size(); i++) {
-            PageDto pageDto = res.get(i);
-            if (pageDto.getPosition() != (i + 1)) {
-                updatePagePosition(i, pageDto);
-            }
-        }
         return res;
-    }
-
-    private void updatePagePosition(int index, PageDto pageDto) {
-        IPage page = pageDto.isOnlineInstance() ? getPageManager().getOnlinePage(pageDto.getCode()) :
-                getPageManager().getDraftPage(pageDto.getCode());
-        page.setPosition(index + 1);
-        try {
-            getPageManager().updatePage(page);
-        } catch (EntException ex) {
-            logger.error("Error updating the position for page {}", page.getCode());
-            throw new RestServerError("Error updating the page position", ex);
-        }
-        pageDto.setPosition(page.getPosition());
     }
 
     @Override

--- a/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
+++ b/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
@@ -225,7 +225,27 @@ public class PageService implements IComponentExistsService, IPageService,
                         res.add(dtoBuilder.convert(childD));
                     }
                 })));
+        // make sure the position is matching the index
+        for (int i = 0; i < res.size(); i++) {
+            PageDto pageDto = res.get(i);
+            if (pageDto.getPosition() != (i + 1)) {
+                updatePagePosition(i, pageDto);
+            }
+        }
         return res;
+    }
+
+    private void updatePagePosition(int index, PageDto pageDto) {
+        IPage page = pageDto.isOnlineInstance() ? getPageManager().getOnlinePage(pageDto.getCode()) :
+                getPageManager().getDraftPage(pageDto.getCode());
+        page.setPosition(index + 1);
+        try {
+            getPageManager().updatePage(page);
+        } catch (EntException ex) {
+            logger.error("Error updating the position for page {}", page.getCode());
+            throw new RestServerError("Error updating the page position", ex);
+        }
+        pageDto.setPosition(page.getPosition());
     }
 
     @Override


### PR DESCRIPTION
The PageTree component on the FE assume the position and the index are the same thing. When trying to fix this on the FE I found many issues and it is hard to keep different position in sync with the index.
This solution is easier and saves many requests in the FE, since there is no need to call the API to update the positions.
Usually the positions will be fixed only the fist time this method is called, since the FE is using the index, it will keep then synced.